### PR TITLE
Delete service (admin), CSS reorganisation, security fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,20 @@
   font-size: 1.6rem;
 }
 
+.blue-btn {
+  transition: 0.6s;
+  border: none;
+  border-radius: 10px;
+  padding: 0.7em 1em;
+  background: #003566;
+  font-size: 1rem;
+  color: #FEFEFE;
+}
+
+.blue-btn:hover {
+  background: #001D3D;
+}
+
 /* CSS rules for modal forms */
 .modal-form-overlay {
   position: fixed;
@@ -540,20 +554,6 @@ nav {
 
 /* || JobsBoard */
 
-.dash-nav-btn {
-  transition: 0.6s;
-  border: none;
-  border-radius: 50px;
-  padding: 0.6em 0.8em;
-  background: #003566;
-  font-size: 1rem;
-  color: #FEFEFE;
-}
-
-.dash-nav-btn:hover {
-  background: #001D3D;
-}
-
 .jobs-board-el {
   border: 2px solid #000814;
   background: #FEFEFE;
@@ -621,25 +621,6 @@ nav {
   justify-content: space-between;
   align-items: center;
   padding: 0 0.8em 0.8em;
-}
-
-.edit-service-btn,
-.delete-btn {
-  transition: 0.6s;
-}
-
-.edit-service-btn {
-  transition: 0.6s;
-  border: none;
-  border-radius: 10px;
-  padding: 0.7em 1em;
-  background: #003566;
-  color: #FEFEFE;
-  font-size: 1rem;
-}
-
-.edit-service-btn:hover {
-  background: #001D3D;
 }
 
 .delete-btn {

--- a/src/App.css
+++ b/src/App.css
@@ -160,6 +160,16 @@
   height: 2.2rem;
 }
 
+.modal-form-wrapper>h4 {
+  margin: 1em 1em 0;
+  font-size: 1.2rem;
+}
+
+.modal-form-wrapper>p {
+  margin: 1em 1em 0;
+  text-align: justify;
+}
+
 .modal-form-wrapper>form>p {
   margin-bottom: 1em;
   font-size: 0.9rem;

--- a/src/App.css
+++ b/src/App.css
@@ -15,14 +15,6 @@
   text-align: center;
 }
 
-.open-element {
-  display: inherit;
-}
-
-.closed-element {
-  display: none;
-}
-
 
 /* REUSABLE ELEMENTS */
 
@@ -30,13 +22,9 @@
 /* CSS rules for page area between nav and footer */
 .page-wrapper {
   margin: 1em 0;
-  padding: 0 1em 1em;
+  padding: 0 0 1em;
   height: 100%;
   background: rgba(254, 254, 254, 0.7);
-}
-
-.page-wrapper h2 {
-  font-weight: 500;
 }
 
 .page-top {
@@ -46,6 +34,12 @@
   margin-bottom: 1em;
   border-bottom: 4px solid #f4f5f7;
   padding: 1.5em 1em;
+}
+
+.page-els-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 1em;
 }
 
 /* CSS rules for unsuccessful RTK query responses e.g. isLoading, isError  */
@@ -69,18 +63,27 @@
 /* CSS rules for modal forms */
 .modal-form-overlay {
   position: fixed;
+  /* Z-index revents later elements from stacking above this overlay */
+  z-index: 1;
   top: 0;
   left: 0;
+  /* Display and align-items allow centering of modal */
+  display: grid;
+  align-items: center;
   overflow: scroll;
   height: 100vh;
   width: 100vw;
   background: rgba(0, 8, 20, 0.7);
 }
 
+.closed-modal {
+  display: none;
+}
+
 .modal-form-wrapper {
   display: flex;
   flex-direction: column;
-  margin: 1em auto 25vh;
+  margin: 1em auto;
   box-shadow: 0 0 4px #222222;
   border-radius: 8px;
   width: 480px;
@@ -95,10 +98,6 @@
   border-radius: 8px 8px 0 0;
   padding: 0.8em;
   background: #FFD60A;
-}
-
-.modal-form-top h3 {
-  font-weight: 500;
 }
 
 .modal-form-wrapper form {
@@ -201,6 +200,8 @@
 @media only screen and (max-width: 559px) {
   .sidebar {
     position: absolute;
+    /* Z-index needed to stack sidebar above positioned elements e.g. login  */
+    z-index: 1;
     left: -50vw;
     /* Height of sidebar is 100% minus combined height of header, nav, and footer */
     height: calc(100% - 208px);
@@ -273,10 +274,6 @@ nav {
   margin: 0 1em;
 }
 
-nav h1 {
-  font-weight: 600;
-}
-
 .nav-icon {
   cursor: pointer;
   font-size: 3rem;
@@ -315,7 +312,11 @@ nav h1 {
 
 /* For placeholder elements on pages with no current content. */
 .temp-wrapper {
-  margin: 8vw auto;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
   box-shadow: 0 0 4px #222222;
   border-radius: 4px;
   width: 360px;
@@ -339,7 +340,11 @@ nav h1 {
 /* || Login */
 
 .login-wrapper {
-  margin: 8vw auto;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
   box-shadow: 0 0 4px #222222;
   border-radius: 4px;
   width: 360px;
@@ -359,7 +364,6 @@ nav h1 {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-weight: 500;
 }
 
 .login-form {
@@ -401,11 +405,6 @@ nav h1 {
 
 /* || Dashboard */
 
-.dashboard-components {
-  display: flex;
-  flex-wrap: wrap;
-}
-
 .dash-comp-wrapper {
   flex-grow: 1;
   margin: 1em;
@@ -420,7 +419,6 @@ nav h1 {
   border-radius: 8px 8px 0 0;
   padding: 1.5em;
   background: #FFD60A;
-  font-weight: 500;
 }
 
 .dash-comp-content {
@@ -563,7 +561,96 @@ nav h1 {
 
 /* || ServicesBoard */
 
+/* Compare to dash-comp-wrapper */
 .services-board-el {
-  border: 2px solid #000814;
-  background: #FEFEFE;
+  margin: 1em;
+  box-shadow: 0 0 4px #222222;
+  border-radius: 8px;
+}
+
+/* || SingleService */
+
+.service-wrapper {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto auto;
+  height: 100%;
+}
+
+.service-wrapper img {
+  object-fit: cover;
+  border-radius: 8px 8px 0 0;
+  aspect-ratio: 16 / 9;
+  width: 100%;
+}
+
+.edit-img-btn {
+  position: absolute;
+  top: 0.6em;
+  right: 0.6em;
+  transition: 0.6s;
+  border: none;
+  border-radius: 50px;
+  height: 3em;
+  width: 3em;
+  background: #001D3D;
+}
+
+.edit-img-btn:hover {
+  opacity: 0.7;
+}
+
+.edit-img-icon {
+  font-size: 1.4rem;
+  color: #FEFEFE;
+}
+
+.service-wrapper h3 {
+  background: #FFD60A;
+  padding: 0.8em;
+  text-align: start;
+}
+
+.service-wrapper p {
+  padding: 1.2em 0.8em;
+  text-align: justify;
+}
+
+.service-btn-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 0.8em 0.8em;
+}
+
+.edit-service-btn,
+.delete-btn {
+  transition: 0.6s;
+}
+
+.edit-service-btn {
+  transition: 0.6s;
+  border: none;
+  border-radius: 10px;
+  padding: 0.7em 1em;
+  background: #003566;
+  color: #FEFEFE;
+  font-size: 1rem;
+}
+
+.edit-service-btn:hover {
+  background: #001D3D;
+}
+
+.delete-btn {
+  transition: 0.6s;
+  border: none;
+  border-radius: 50px;
+  height: 3em;
+  width: 3em;
+  background: #FFD60A;
+}
+
+.delete-icon {
+  font-size: 1.4rem;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -74,6 +74,12 @@
   background: #001D3D;
 }
 
+.icon-btn {
+  border-radius: 50px;
+  height: 3em;
+  width: 3em;
+}
+
 /* CSS rules for modal forms */
 .modal-form-overlay {
   position: fixed;
@@ -461,9 +467,6 @@ nav {
 
 .user-profile-btn {
   border: 1px solid #000814;
-  border-radius: 50px;
-  height: 3em;
-  width: 3em;
   background: #FEFEFE;
 }
 
@@ -590,9 +593,6 @@ nav {
   right: 0.6em;
   transition: 0.6s;
   border: none;
-  border-radius: 50px;
-  height: 3em;
-  width: 3em;
   background: #001D3D;
 }
 
@@ -626,9 +626,6 @@ nav {
 .delete-btn {
   transition: 0.6s;
   border: none;
-  border-radius: 50px;
-  height: 3em;
-  width: 3em;
   background: #FFD60A;
 }
 

--- a/src/features/admin/Login.tsx
+++ b/src/features/admin/Login.tsx
@@ -64,7 +64,7 @@ const Login: React.FC = () => {
           onFocus={() => setErrorMsg("")} />
 
         <input
-          type="text"
+          type="password"
           id="admin-password-input"
           placeholder="Password"
           required

--- a/src/features/admin/dashboard/Dashboard.tsx
+++ b/src/features/admin/dashboard/Dashboard.tsx
@@ -14,7 +14,7 @@ const Dashboard: React.FC = () => {
         <UserProfile />
       </div>
 
-      <div className="dashboard-components">
+      <div className="page-els-wrapper">
         <BusinessInfoDisplay />
         <JobsDisplay />
         <ServicesDisplay />

--- a/src/features/admin/dashboard/businessInfo/BusinessInfoUpdater.tsx
+++ b/src/features/admin/dashboard/businessInfo/BusinessInfoUpdater.tsx
@@ -49,9 +49,9 @@ const BusinessInfoUpdater: React.FC = () => {
 
   return (
     <div className={isFormToggled ? (
-      "modal-form-overlay open-element"
+      "modal-form-overlay"
     ) : (
-      "modal-form-overlay closed-element"
+      "modal-form-overlay closed-modal"
     )}>
 
       <div className="modal-form-wrapper">

--- a/src/features/admin/dashboard/userProfile/UserProfile.tsx
+++ b/src/features/admin/dashboard/userProfile/UserProfile.tsx
@@ -10,9 +10,9 @@ const UserProfile: React.FC = () => {
     <>
       <button
         className={!isProfileOpen ? (
-          "user-profile-btn"
+          "user-profile-btn icon-btn"
         ) : (
-          "user-profile-btn user-profile-btn-clicked"
+          "user-profile-btn icon-btn user-profile-btn-clicked"
         )}
         onClick={() => setIsProfileOpen(!isProfileOpen)}>
         <FaUser className="user-profile-icon" />

--- a/src/features/api/apiSlice.ts
+++ b/src/features/api/apiSlice.ts
@@ -37,6 +37,17 @@ export const apiSlice = createApi({
       invalidatesTags: ["services"]
     }),
 
+    deleteService: builder.mutation<void, { name: string, token: string }>({
+      query: ({ name, token }) => ({
+        url: `/jobtypes/${name}`,
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      }),
+      invalidatesTags: ["services"]
+    }),
+
     getBusinessInfo: builder.query<BusinessInfo, void>({
       query: () => "/info",
       providesTags: ["businessInfo"]
@@ -79,6 +90,7 @@ export const {
   useGetJobsQuery,
   useGetServicesQuery,
   useUpdateServiceDescriptionMutation,
+  useDeleteServiceMutation,
   useGetBusinessInfoQuery,
   useUpdateBusinessInfoMutation,
   useLoginMutation,

--- a/src/features/jobs/JobsBoard.tsx
+++ b/src/features/jobs/JobsBoard.tsx
@@ -55,7 +55,7 @@ const JobsBoard: React.FC = () => {
       <div className="page-top">
         <h2>Jobs</h2>
         <Link to="/admin">
-          <button className="dash-nav-btn">
+          <button className="blue-btn">
             Dashboard
           </button>
         </Link>

--- a/src/features/services/ServiceDeleter.tsx
+++ b/src/features/services/ServiceDeleter.tsx
@@ -1,0 +1,98 @@
+import { FaRegWindowClose } from "react-icons/fa"
+import { useAppDispatch, useAppSelector } from "../../app/hooks"
+import { Service } from "../../models"
+import { formatHeader } from "../../utils/formattingUtils"
+import { closeServiceDeleter } from "./servicesSlice"
+import { SubmitHandler, useForm } from "react-hook-form"
+import { useState } from "react"
+
+type Props = {
+  service: Service
+}
+
+type FormValues = {
+  name: string
+}
+
+const ServiceDeleter: React.FC<Props> = ({ service }) => {
+
+  const dispatch = useAppDispatch()
+
+  const { isDeleterToggled, selectedService } = useAppSelector(state => state.services)
+
+  const [errorMsg, setErrorMsg] = useState<string>("")
+
+  const {
+    register,
+    handleSubmit,
+    reset
+  } = useForm<FormValues>()
+
+  const submitForm: SubmitHandler<FormValues> = ({ name }) => {
+    const currentUser = localStorage.getItem("name")
+    if (currentUser === name) {
+      reset()
+      dispatch(closeServiceDeleter())
+      document.body.style.overflow = "auto"
+      setErrorMsg("")
+    } else {
+      setErrorMsg("Incorrect admin name.")
+    }
+  }
+
+  return (
+    <div className={isDeleterToggled && selectedService === service.name ? (
+      "modal-form-overlay"
+    ) : (
+      "modal-form-overlay closed-modal"
+    )}>
+
+      <div className="modal-form-wrapper">
+
+        <div className="modal-form-top">
+          <h3>Delete {formatHeader(service.name)}</h3>
+          <button
+            className="window-close-btn"
+            onClick={() => {
+              dispatch(closeServiceDeleter())
+              document.body.style.overflow = "auto"
+            }}>
+            <FaRegWindowClose className="window-close-icon" />
+          </button>
+        </div>
+
+        <h4>Warning!</h4>
+
+        <p>Deleting this service will also delete all associated jobs. This process is irreversible. If you are sure you wish to proceed, please enter your admin name.</p>
+
+        <form
+          onSubmit={handleSubmit(submitForm)}
+          onChange={() => setErrorMsg("")}>
+
+          <label htmlFor={`delete-${service.name}-name-input`}>
+            Admin name:
+          </label>
+          <input
+            type="text"
+            id={`delete-${service.name}-name-input`}
+            autoComplete="true"
+            required
+            {...register("name")} />
+
+          <button
+            type="submit"
+            className="modal-btn">
+            DELETE
+          </button>
+
+          {errorMsg ? <p className="rtk-query-form-msg">{errorMsg}</p> : null}
+
+        </form>
+
+      </div>
+
+    </div>
+  )
+}
+
+export default ServiceDeleter

--- a/src/features/services/ServiceDeleter.tsx
+++ b/src/features/services/ServiceDeleter.tsx
@@ -78,7 +78,9 @@ const ServiceDeleter: React.FC<Props> = ({ service }) => {
 
         <h4>Warning!</h4>
 
-        <p>Deleting this service will also delete all associated jobs. This process is irreversible. If you are sure you wish to proceed, please enter your admin name.</p>
+        <p>Deleting this service will also delete <b>all</b> associated jobs. This process is irreversible.</p>
+
+        <p>If you are sure you wish to proceed, please enter your admin name and click delete.</p>
 
         <form
           onSubmit={handleSubmit(submitForm)}

--- a/src/features/services/ServiceUpdater.tsx
+++ b/src/features/services/ServiceUpdater.tsx
@@ -1,7 +1,7 @@
 import { FaRegWindowClose } from "react-icons/fa"
 import { Service } from "../../models"
 import { useAppDispatch, useAppSelector } from "../../app/hooks"
-import { closeServiceForm } from "./servicesSlice"
+import { closeServiceUpdater } from "./servicesSlice"
 import { formatHeader } from "../../utils/formattingUtils"
 import { SubmitHandler, useForm } from "react-hook-form"
 import { useCookies } from "react-cookie"
@@ -54,7 +54,7 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
         },
         token: token
       }).unwrap()
-      dispatch(closeServiceForm())
+      dispatch(closeServiceUpdater())
       document.body.style.overflow = "auto"
       setErrorMsg("")
     } catch (error: any) {
@@ -77,7 +77,7 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
           <button
             className="window-close-btn"
             onClick={() => {
-              dispatch(closeServiceForm())
+              dispatch(closeServiceUpdater())
               document.body.style.overflow = "auto"
             }}>
             <FaRegWindowClose className="window-close-icon" />

--- a/src/features/services/ServiceUpdater.tsx
+++ b/src/features/services/ServiceUpdater.tsx
@@ -22,7 +22,7 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
 
   const dispatch = useAppDispatch()
 
-  const { isFormToggled, selectedService } = useAppSelector(state => state.services)
+  const { isUpdaterToggled, selectedService } = useAppSelector(state => state.services)
 
   const [{ token }] = useCookies(["token"])
 
@@ -64,7 +64,7 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
   }
 
   return (
-    <div className={isFormToggled && selectedService === service.name ? (
+    <div className={isUpdaterToggled && selectedService === service.name ? (
       "modal-form-overlay"
     ) : (
       "modal-form-overlay closed-modal"
@@ -86,12 +86,12 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
 
         <form onSubmit={handleSubmit(submitForm)}>
 
-          <label htmlFor="service-description-input">
+          <label htmlFor={`${service.name}-description-input`}>
             Service description: <span>*</span>
           </label>
           <textarea
             rows={5}
-            id="service-description-input"
+            id={`${service.name}-description-input`}
             autoComplete="true"
             required
             {...register("description")} />

--- a/src/features/services/ServiceUpdater.tsx
+++ b/src/features/services/ServiceUpdater.tsx
@@ -65,9 +65,9 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
 
   return (
     <div className={isFormToggled && selectedService === service.name ? (
-      "modal-form-overlay open-element"
+      "modal-form-overlay"
     ) : (
-      "modal-form-overlay closed-element"
+      "modal-form-overlay closed-modal"
     )}>
 
       <div className="modal-form-wrapper">

--- a/src/features/services/ServicesBoard.tsx
+++ b/src/features/services/ServicesBoard.tsx
@@ -44,7 +44,7 @@ const ServicesBoard: React.FC = () => {
       <div className="page-top">
         <h2>Services</h2>
         <Link to="/admin">
-          <button className="dash-nav-btn">
+          <button className="blue-btn">
             Dashboard
           </button>
         </Link>

--- a/src/features/services/ServicesBoard.tsx
+++ b/src/features/services/ServicesBoard.tsx
@@ -3,6 +3,7 @@ import { useGetServicesQuery } from "../api/apiSlice"
 import { Service } from "../../models"
 import SingleService from "./SingleService"
 import ServiceUpdater from "./ServiceUpdater"
+import ServiceDeleter from "./ServiceDeleter"
 
 const ServicesBoard: React.FC = () => {
 
@@ -32,6 +33,7 @@ const ServicesBoard: React.FC = () => {
             className="services-board-el">
             <SingleService service={service} />
             <ServiceUpdater service={service} />
+            <ServiceDeleter service={service} />
           </li>
         )
       })}

--- a/src/features/services/ServicesBoard.tsx
+++ b/src/features/services/ServicesBoard.tsx
@@ -24,7 +24,7 @@ const ServicesBoard: React.FC = () => {
   }
 
   if (isSuccess) content = (
-    <ul>
+    <ul className="page-els-wrapper">
       {services.map((service: Service) => {
         return (
           <li

--- a/src/features/services/SingleService.tsx
+++ b/src/features/services/SingleService.tsx
@@ -1,6 +1,6 @@
 import { useAppDispatch } from "../../app/hooks"
 import { Service } from "../../models"
-import { openServiceUpdater } from "./servicesSlice"
+import { openServiceDeleter, openServiceUpdater } from "./servicesSlice"
 import { FaCamera, FaTrashAlt } from "react-icons/fa"
 
 type Props = {
@@ -37,7 +37,11 @@ const SingleService: React.FC<Props> = ({ service }) => {
         </button>
 
         <button
-          className="delete-btn icon-btn">
+          className="delete-btn icon-btn"
+          onClick={() => {
+            dispatch(openServiceDeleter(service.name))
+            document.body.style.overflow = "hidden"
+          }}>
           <FaTrashAlt className="delete-icon" />
         </button>
 

--- a/src/features/services/SingleService.tsx
+++ b/src/features/services/SingleService.tsx
@@ -23,7 +23,7 @@ const SingleService: React.FC<Props> = ({ service }) => {
       <p>{service.description}</p>
       <div className="service-btn-wrapper">
         <button
-          className="edit-service-btn"
+          className="blue-btn"
           onClick={() => {
             dispatch(openServiceForm(service.name))
             document.body.style.overflow = "hidden"

--- a/src/features/services/SingleService.tsx
+++ b/src/features/services/SingleService.tsx
@@ -13,15 +13,20 @@ const SingleService: React.FC<Props> = ({ service }) => {
 
   return (
     <div className="service-wrapper">
+
       {/* <img src={service.image} alt={`Image for ${service.name}`} /> */}
       {/* Using construction.jpg as an example during development */}
       <img src="/construction.jpg" alt={`Image for ${service.name}`} />
-      <button className="edit-img-btn">
+      <button className="edit-img-btn icon-btn">
         <FaCamera className="edit-img-icon" />
       </button>
+
       <h3>{service.name}</h3>
+
       <p>{service.description}</p>
+
       <div className="service-btn-wrapper">
+
         <button
           className="blue-btn"
           onClick={() => {
@@ -30,11 +35,14 @@ const SingleService: React.FC<Props> = ({ service }) => {
           }}>
           Edit Description
         </button>
+
         <button
-          className="delete-btn">
+          className="delete-btn icon-btn">
           <FaTrashAlt className="delete-icon" />
         </button>
+        
       </div>
+
     </div>
   )
 }

--- a/src/features/services/SingleService.tsx
+++ b/src/features/services/SingleService.tsx
@@ -1,6 +1,7 @@
 import { useAppDispatch } from "../../app/hooks"
 import { Service } from "../../models"
 import { openServiceForm } from "./servicesSlice"
+import { FaCamera, FaTrashAlt } from "react-icons/fa"
 
 type Props = {
   service: Service
@@ -11,21 +12,30 @@ const SingleService: React.FC<Props> = ({ service }) => {
   const dispatch = useAppDispatch()
 
   return (
-    <>
-      <img src={service.image} alt={`Image for ${service.name}`} />
+    <div className="service-wrapper">
+      {/* <img src={service.image} alt={`Image for ${service.name}`} /> */}
+      {/* Using construction.jpg as an example during development */}
+      <img src="/construction.jpg" alt={`Image for ${service.name}`} />
+      <button className="edit-img-btn">
+        <FaCamera className="edit-img-icon" />
+      </button>
       <h3>{service.name}</h3>
       <p>{service.description}</p>
-      <div>
+      <div className="service-btn-wrapper">
         <button
+          className="edit-service-btn"
           onClick={() => {
             dispatch(openServiceForm(service.name))
             document.body.style.overflow = "hidden"
           }}>
-          Edit
+          Edit Description
         </button>
-        <button>Delete</button>
+        <button
+          className="delete-btn">
+          <FaTrashAlt className="delete-icon" />
+        </button>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/src/features/services/SingleService.tsx
+++ b/src/features/services/SingleService.tsx
@@ -1,6 +1,6 @@
 import { useAppDispatch } from "../../app/hooks"
 import { Service } from "../../models"
-import { openServiceForm } from "./servicesSlice"
+import { openServiceUpdater } from "./servicesSlice"
 import { FaCamera, FaTrashAlt } from "react-icons/fa"
 
 type Props = {
@@ -30,7 +30,7 @@ const SingleService: React.FC<Props> = ({ service }) => {
         <button
           className="blue-btn"
           onClick={() => {
-            dispatch(openServiceForm(service.name))
+            dispatch(openServiceUpdater(service.name))
             document.body.style.overflow = "hidden"
           }}>
           Edit Description
@@ -40,7 +40,7 @@ const SingleService: React.FC<Props> = ({ service }) => {
           className="delete-btn icon-btn">
           <FaTrashAlt className="delete-icon" />
         </button>
-        
+
       </div>
 
     </div>

--- a/src/features/services/servicesSlice.ts
+++ b/src/features/services/servicesSlice.ts
@@ -1,12 +1,14 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit"
 
 type ServicesState = {
-  isFormToggled: boolean
+  isUpdaterToggled: boolean
+  isDeleterToggled: boolean
   selectedService: string | undefined
 }
 
 const initialState: ServicesState = {
-  isFormToggled: false,
+  isUpdaterToggled: false,
+  isDeleterToggled: false,
   selectedService: undefined
 }
 
@@ -15,11 +17,19 @@ const servicesSlice = createSlice({
   initialState,
   reducers: {
     openServiceUpdater: (state, action: PayloadAction<string>) => {
-      state.isFormToggled = true
+      state.isUpdaterToggled = true
       state.selectedService = action.payload
     },
     closeServiceUpdater: (state) => {
-      state.isFormToggled = false
+      state.isUpdaterToggled = false
+      state.selectedService = undefined
+    },
+    openServiceDeleter: (state, action: PayloadAction<string>) => {
+      state.isDeleterToggled = true
+      state.selectedService = action.payload
+    },
+    closeServiceDeleter: (state) => {
+      state.isDeleterToggled = false
       state.selectedService = undefined
     }
   }
@@ -27,7 +37,9 @@ const servicesSlice = createSlice({
 
 export const {
   openServiceUpdater,
-  closeServiceUpdater
+  closeServiceUpdater,
+  openServiceDeleter,
+  closeServiceDeleter
 } = servicesSlice.actions
 
 export default servicesSlice.reducer

--- a/src/features/services/servicesSlice.ts
+++ b/src/features/services/servicesSlice.ts
@@ -14,11 +14,11 @@ const servicesSlice = createSlice({
   name: "services",
   initialState,
   reducers: {
-    openServiceForm: (state, action: PayloadAction<string>) => {
+    openServiceUpdater: (state, action: PayloadAction<string>) => {
       state.isFormToggled = true
       state.selectedService = action.payload
     },
-    closeServiceForm: (state) => {
+    closeServiceUpdater: (state) => {
       state.isFormToggled = false
       state.selectedService = undefined
     }
@@ -26,8 +26,8 @@ const servicesSlice = createSlice({
 })
 
 export const {
-  openServiceForm,
-  closeServiceForm
+  openServiceUpdater,
+  closeServiceUpdater
 } = servicesSlice.actions
 
 export default servicesSlice.reducer

--- a/src/index.css
+++ b/src/index.css
@@ -23,7 +23,8 @@ input {
   font-size: 16px;
 }
 
-h1 {
+h1,
+h4 {
   font-weight: 600;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,15 @@ input {
   font-size: 16px;
 }
 
+h1 {
+  font-weight: 600;
+}
+
+h2,
+h3 {
+  font-weight: 500;
+}
+
 header {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
- Display update to ensure certain elements are properly centred.
- Reorganisation of stylesheet to reduce repetition and overly specific styling.
- Password input fields now have the password type rather than text.
- Admins can now delete a service (and all associated jobs).