### PR TITLE
JobAdder Form Field Population and Page Navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,10 +77,6 @@
   font-size: 1rem;
 }
 
-.yellow-btn {
-  background: #FFD60A;
-}
-
 .blue-btn {
   background: #003566;
   color: #FEFEFE;
@@ -88,6 +84,10 @@
 
 .blue-btn:hover {
   background: #001D3D;
+}
+
+.yellow-btn {
+  background: #FFD60A;
 }
 
 .yellow-btn:hover {
@@ -129,7 +129,7 @@
 /* CSS rules for modal forms */
 .modal-form-overlay {
   position: fixed;
-  /* Z-index revents later elements from stacking above this overlay */
+  /* Z-index prevents later elements from stacking above this overlay */
   z-index: 1;
   top: 0;
   left: 0;

--- a/src/features/admin/dashboard/jobs/JobsDisplay.tsx
+++ b/src/features/admin/dashboard/jobs/JobsDisplay.tsx
@@ -22,7 +22,7 @@ const JobsDisplay: React.FC = () => {
 
   if (isSuccess) content = (
     <div className="dash-comp-content">
-      <p>There are currently {jobs.length} jobs listed.</p>
+      <p>There are currently <b>{jobs.length}</b> jobs listed across all service categories.</p>
     </div>
   )
 

--- a/src/features/admin/dashboard/services/ServicesDisplay.tsx
+++ b/src/features/admin/dashboard/services/ServicesDisplay.tsx
@@ -25,7 +25,7 @@ const ServicesDisplay: React.FC = () => {
 
   if (isSuccess) content = (
     <div className="dash-comp-content">
-      <p>There are currently {services.length} services listed.</p>
+      <p>There are currently <b>{services.length}</b> service categories listed.</p>
     </div>
   )
 

--- a/src/features/api/apiSlice.ts
+++ b/src/features/api/apiSlice.ts
@@ -28,7 +28,7 @@ export const apiSlice = createApi({
         },
         body: job
       }),
-      invalidatesTags: ["jobs"]
+      invalidatesTags: ["jobs", "services"]
     }),
 
     getServices: builder.query<Service[], void>({

--- a/src/features/api/apiSlice.ts
+++ b/src/features/api/apiSlice.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
-import { Job, Service, BusinessInfo, LoginResponse, LoginRequest, JobRequest } from "../../models"
+import { Job, Service, BusinessInfo, LoginResponse, LoginRequest, JobRequest, ServiceRequest } from "../../models"
 
 
 export const apiSlice = createApi({
@@ -36,7 +36,7 @@ export const apiSlice = createApi({
       providesTags: ["services"]
     }),
 
-    addService: builder.mutation<Service, { service: Service, token: string }>({
+    addService: builder.mutation<Service, { service: ServiceRequest, token: string }>({
       query: ({ service, token }) => ({
         url: "/jobtypes",
         method: "POST",
@@ -60,7 +60,7 @@ export const apiSlice = createApi({
       invalidatesTags: ["services"]
     }),
 
-    updateServiceDescription: builder.mutation<Service, { service: Service, token: string }>({
+    updateServiceDescription: builder.mutation<Service, { service: ServiceRequest, token: string }>({
       query: ({ service, token }) => ({
         url: `/jobtypes/${service.name}`,
         method: "PATCH",

--- a/src/features/jobs/JobAdder.tsx
+++ b/src/features/jobs/JobAdder.tsx
@@ -6,7 +6,7 @@ import { useState } from "react"
 import { useAddJobMutation, useGetServicesQuery } from "../api/apiSlice"
 import { useCookies } from "react-cookie"
 import { JobRequest } from "../../models"
-import { useParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 
 
 const JobAdder: React.FC = () => {
@@ -15,6 +15,8 @@ const JobAdder: React.FC = () => {
   const dispatch = useAppDispatch()
 
   const { isJobAdderToggled } = useAppSelector(state => state.jobs)
+
+  const navigate = useNavigate()
 
   const { service } = useParams()
 
@@ -54,6 +56,27 @@ const JobAdder: React.FC = () => {
       )
     })
   )
+
+
+  const handleClick = () => {
+
+    reset()
+
+    dispatch(closeJobAdder())
+
+    document.body.style.overflow = "auto"
+
+    // First if statement avoids error on page with no :service params
+    if (service) {
+      // Filter used here because GET request to /jobtypes/{name} throws error when {name} is undefined
+      if (!services?.filter((singleService) => {
+        return singleService.name === service
+      })[0].count) {
+        navigate("/admin/jobs")
+      }
+    }
+
+  }
 
 
   const submitForm: SubmitHandler<JobRequest> = async (job) => {
@@ -101,11 +124,7 @@ const JobAdder: React.FC = () => {
 
           <button
             className="window-close-btn"
-            onClick={() => {
-              reset()
-              dispatch(closeJobAdder())
-              document.body.style.overflow = "auto"
-            }}>
+            onClick={() => handleClick()}>
             <FaRegWindowClose className="window-close-icon" />
           </button>
 

--- a/src/features/jobs/Jobs.tsx
+++ b/src/features/jobs/Jobs.tsx
@@ -5,6 +5,9 @@ import { formatHeader } from "../../utils/formattingUtils"
 import { useGetJobsQuery } from "../api/apiSlice"
 import AddJobBtn from "./AddJobBtn"
 import JobAdder from "./JobAdder"
+import { useEffect } from "react"
+import { useAppDispatch } from "../../app/hooks"
+import { openJobAdder } from "./jobsSlice"
 
 
 type Props = {
@@ -15,6 +18,8 @@ type Props = {
 const Jobs: React.FC<Props> = ({ service }) => {
 
 
+  const dispatch = useAppDispatch()
+
   const {
     data: jobs,
     isLoading,
@@ -22,6 +27,14 @@ const Jobs: React.FC<Props> = ({ service }) => {
     isError,
     error
   } = useGetJobsQuery()
+  
+  useEffect(() => {
+    if (!jobs?.filter((job: Job) => {
+      return job.job_Type === service
+    }).length) {
+      dispatch(openJobAdder())
+    }
+  }, [])
 
 
   let content

--- a/src/features/jobs/JobsBoardServiceCard.tsx
+++ b/src/features/jobs/JobsBoardServiceCard.tsx
@@ -29,7 +29,7 @@ const JobsBoardServiceCard: React.FC<Props> = ({ service, jobs }) => {
 
         <h3>{formatHeader(service.name)}</h3>
 
-        <p>There {formatJobsData(jobs, service)} in the <span>{formatHeader(service.name)}</span> service category.</p>
+        <p>There {formatJobsData(service.count)} in the <span>{formatHeader(service.name)}</span> service category.</p>
 
       </div>
 

--- a/src/features/jobs/JobsBoardServiceCard.tsx
+++ b/src/features/jobs/JobsBoardServiceCard.tsx
@@ -2,8 +2,6 @@ import { useNavigate } from "react-router-dom"
 import { Job, Service } from "../../models"
 import { formatHeader, formatJobsData } from "../../utils/formattingUtils"
 import { checkJobs } from "../../utils/logicalUtils"
-import { useAppDispatch } from "../../app/hooks"
-import { openJobAdder } from "./jobsSlice"
 
 
 type Props = {
@@ -14,8 +12,6 @@ type Props = {
 
 const JobsBoardServiceCard: React.FC<Props> = ({ service, jobs }) => {
 
-
-  const dispatch = useAppDispatch()
 
   const navigate = useNavigate()
 
@@ -33,24 +29,11 @@ const JobsBoardServiceCard: React.FC<Props> = ({ service, jobs }) => {
 
       </div>
 
-      {checkJobs(jobs, service) ? (
-        <button
-          className="dashboard-btn jobs-board-btn"
-          onClick={() => {
-            navigate(`/admin/jobs/${service.name}`)
-          }}>
-          Manage jobs
-        </button>
-      ) : (
-        <button 
+      <button
         className="dashboard-btn jobs-board-btn"
-        onClick={() => {
-          dispatch(openJobAdder())
-          document.body.style.overflow = "hidden"
-        }}>
-          Add a job
-        </button>
-      )}
+        onClick={() => navigate(`/admin/jobs/${service.name}`)}>
+        {checkJobs(jobs, service) ? "Manage jobs" : "Add a job"}
+      </button>
 
     </div>
   )

--- a/src/models.ts
+++ b/src/models.ts
@@ -23,6 +23,14 @@ export type Service = {
   description: string
   image: string
   icon: string
+  count: number
+}
+
+export type ServiceRequest = {
+  name: string
+  description: string
+  image: string
+  icon: string
 }
 
 export type BusinessInfo = {

--- a/src/utils/formattingUtils.ts
+++ b/src/utils/formattingUtils.ts
@@ -1,17 +1,10 @@
-import { Job, Service } from "../models"
+export const formatJobsData = (count: number): string => {
 
+  if (count === 0) return "are no jobs"
 
-export const formatJobsData = (jobs: Job[], service: Service): string => {
+  if (count === 1) return "is 1 job"
 
-  const res = jobs.filter((job) => {
-    return job.job_Type === service.name
-  }).length
-
-  if (res === 0) return "are no jobs"
-
-  if (res === 1) return "is 1 job"
-
-  return `are ${res} jobs`
+  return `are ${count} jobs`
 }
 
 


### PR DESCRIPTION
- Refactoring to use the new count property on the service object.
- Applies functionality to pre-populate the 'service' field on the JobAdder form when users click 'Add a job' from the jobs board.
- Sets up logic to open the JobAdder form when the user navigates to an empty jobs page, and navigate back to the jobs board if the form is closed while the page remains empty.