### PR TITLE
Missing Overflow Property

### DIFF
--- a/src/features/jobs/SingleJob.tsx
+++ b/src/features/jobs/SingleJob.tsx
@@ -82,6 +82,7 @@ const SingleJob: React.FC = () => {
               className="yellow-btn icon-btn"
               onClick={() => {
                 dispatch(openJobDeleter())
+                document.body.style.overflow = "hidden"
               }}>
               <FaTrashAlt className="btn-icon" />
             </button>


### PR DESCRIPTION
- Adds missing overflow property to ensure background scrolling is disabled when JobDeleter is open.