### PR TITLE
Update Job Functionality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -795,7 +795,7 @@ nav {
 .single-job-wrapper {
   box-shadow: 0 0 4px #222222;
   border-radius: 8px;
-  max-width: 95vw;
+  max-width: 720px;
   background: #FEFEFE;
   text-align: start;
 }

--- a/src/features/admin/dashboard/businessInfo/BusinessInfoUpdater.tsx
+++ b/src/features/admin/dashboard/businessInfo/BusinessInfoUpdater.tsx
@@ -35,7 +35,7 @@ const BusinessInfoUpdater: React.FC = () => {
   })
 
 
-  const submitForm: SubmitHandler<BusinessInfo> = async (businessInfo: BusinessInfo) => {
+  const submitForm: SubmitHandler<BusinessInfo> = async (businessInfo) => {
 
     try {
       await updateBusinessInfo({

--- a/src/features/admin/dashboard/businessInfo/BusinessInfoUpdater.tsx
+++ b/src/features/admin/dashboard/businessInfo/BusinessInfoUpdater.tsx
@@ -78,6 +78,7 @@ const BusinessInfoUpdater: React.FC = () => {
           <button
             className="window-close-btn"
             onClick={() => {
+              reset(info)
               dispatch(closeBusinessInfoForm())
               document.body.style.overflow = "auto"
             }}>

--- a/src/features/api/apiSlice.ts
+++ b/src/features/api/apiSlice.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
-import { Job, Service, BusinessInfo, LoginResponse, LoginRequest, JobRequest, ServiceRequest } from "../../models"
+import { Job, Service, BusinessInfo, LoginResponse, LoginRequest, JobRequest, ServiceRequest, JobUpdate } from "../../models"
 
 
 export const apiSlice = createApi({
@@ -10,7 +10,7 @@ export const apiSlice = createApi({
     baseUrl: "http://4.234.160.181:8080/construction/api"
   }),
 
-  tagTypes: ["businessInfo", "jobs", "services"],
+  tagTypes: ["businessInfo", "jobs", "job", "services"],
 
   endpoints: builder => ({
 
@@ -20,7 +20,8 @@ export const apiSlice = createApi({
     }),
 
     getJobById: builder.query<Job, { id: string | undefined }>({
-      query: ({ id }) => `/jobs/${id}`
+      query: ({ id }) => `/jobs/${id}`,
+      providesTags: ["job"]
     }),
 
     addJob: builder.mutation<Job, { job: JobRequest, token: string }>({
@@ -33,6 +34,18 @@ export const apiSlice = createApi({
         body: job
       }),
       invalidatesTags: ["jobs", "services"]
+    }),
+
+    updateJob: builder.mutation<Job, { job: JobUpdate, id: number, token: string }>({
+      query: ({ job, id, token }) => ({
+        url: `/jobs/${id}`,
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`
+        },
+        body: job
+      }),
+      invalidatesTags: ["jobs", "job", "services"]
     }),
 
     deleteJob: builder.mutation<void, { id: number, token: string }>({
@@ -155,6 +168,7 @@ export const {
   useGetJobsQuery,
   useGetJobByIdQuery,
   useAddJobMutation,
+  useUpdateJobMutation,
   useDeleteJobMutation,
   useGetServicesQuery,
   useAddServiceMutation,

--- a/src/features/jobs/JobUpdater.tsx
+++ b/src/features/jobs/JobUpdater.tsx
@@ -3,6 +3,8 @@ import { useAppDispatch, useAppSelector } from "../../app/hooks"
 import { closeJobUpdater } from "./jobsSlice"
 import { Job } from "../../models"
 import { formatHeader } from "../../utils/formattingUtils"
+import { SubmitHandler, useForm } from "react-hook-form"
+import { useState } from "react"
 
 
 type Props = {
@@ -10,12 +12,46 @@ type Props = {
 }
 
 
+type FormValues = {
+  title: string
+  tagline: string
+  description: string
+  client: string
+  location: string
+}
+
+
 const JobUpdater: React.FC<Props> = ({ job }) => {
+
+
+  const currentData = {
+    title: job.title,
+    tagline: job.tagline,
+    description: job.description,
+    client: job.client,
+    location: job.location
+  }
 
 
   const dispatch = useAppDispatch()
 
   const { isJobUpdaterToggled } = useAppSelector(state => state.jobs)
+
+  const [charLimit, setCharLimit] = useState<number>(job.description.length)
+
+  const {
+    register,
+    handleSubmit,
+    reset
+  } = useForm<FormValues>({
+    defaultValues: currentData,
+    values: currentData
+  })
+
+
+  const submitForm: SubmitHandler<FormValues> = (data) => {
+    console.log(data)
+  }
 
 
   return (
@@ -34,6 +70,7 @@ const JobUpdater: React.FC<Props> = ({ job }) => {
           <button
             className="window-close-btn"
             onClick={() => {
+              reset(currentData)
               dispatch(closeJobUpdater())
               document.body.style.overflow = "auto"
             }}>
@@ -42,7 +79,97 @@ const JobUpdater: React.FC<Props> = ({ job }) => {
 
         </div>
 
-        <form>
+        <form onSubmit={handleSubmit(submitForm)}>
+
+          <label htmlFor="job-title-input">
+            Job title: <span>*</span>
+          </label>
+
+          <input
+            type="text"
+            id="job-title-input"
+            autoComplete="true"
+            required
+            {...register("title")} />
+
+          <label htmlFor="job-tagline-input">
+            Tagline: <span>*</span>
+          </label>
+
+          <input
+            type="text"
+            id="job-tagline-input"
+            autoComplete="true"
+            required
+            {...register("tagline")} />
+
+          <label htmlFor="job-client-input">
+            Client: <span>*</span>
+          </label>
+
+          <input
+            type="text"
+            id="job-client-input"
+            autoComplete="true"
+            required
+            {...register("client")} />
+
+          <label htmlFor="job-location-input">
+            Location: <span>*</span>
+          </label>
+
+          <input
+            type="text"
+            id="job-location-input"
+            autoComplete="true"
+            required
+            {...register("location")} />
+
+          <label htmlFor="job-description-input">
+            Job description: <span>*</span>
+          </label>
+
+          <textarea
+            rows={5}
+            id="job-description-input"
+            autoComplete="true"
+            maxLength={200}
+            required
+            {...register("description", {
+              onChange: (e) => {
+                setCharLimit(e.target.value.length)
+              }
+            })} />
+
+          <p>{200 - charLimit} characters remaining.</p>
+
+          <div className="modal-btn-wrapper">
+
+            <button
+              type="button"
+              className="modal-btn-small yellow-btn"
+              onClick={() => {
+                reset(currentData)
+                setCharLimit(job.description.length)
+              }}>
+              Reset
+            </button>
+
+            <button
+              type="reset"
+              className="modal-btn-small yellow-btn"
+              onClick={() => setCharLimit(0)}>
+              Clear
+            </button>
+
+          </div>
+
+          <button
+            type="submit"
+            className="modal-btn blue-btn">
+            Submit
+          </button>
+
         </form>
       </div>
     </div>

--- a/src/features/jobs/Jobs.tsx
+++ b/src/features/jobs/Jobs.tsx
@@ -47,6 +47,10 @@ const Jobs: React.FC<Props> = ({ service }) => {
 
           {jobs.filter((job: Job) => {
             return job.job_Type === service
+          }).sort((a, b) => {
+            if (a.job_Id < b.job_Id) return 1
+            if (a.job_Id > b.job_Id) return -1
+            return 0
           }).map((job) => {
             return (
               <li

--- a/src/features/services/ServiceUpdater.tsx
+++ b/src/features/services/ServiceUpdater.tsx
@@ -22,8 +22,6 @@ type FormValues = {
 const ServiceUpdater: React.FC<Props> = ({ service }) => {
 
 
-  const { name, image, icon } = service
-
   const dispatch = useAppDispatch()
 
   const { isServiceUpdaterToggled, selectedService } = useAppSelector(state => state.services)
@@ -54,10 +52,10 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
     try {
       await updateServiceDescription({
         service: {
-          name: name,
+          name: service.name,
           description: serviceDetails.description,
-          image: image,
-          icon: icon
+          image: service.image,
+          icon: service.icon
         },
         token: token
       }).unwrap()

--- a/src/features/services/ServiceUpdater.tsx
+++ b/src/features/services/ServiceUpdater.tsx
@@ -96,6 +96,9 @@ const ServiceUpdater: React.FC<Props> = ({ service }) => {
           <button
             className="window-close-btn"
             onClick={() => {
+              reset({
+                description: service.description
+              })
               dispatch(closeServiceUpdater())
               document.body.style.overflow = "auto"
             }}>

--- a/src/models.ts
+++ b/src/models.ts
@@ -9,6 +9,14 @@ export type Job = {
   location: string
 }
 
+export type JobUpdate = {
+  title: string
+  tagline: string
+  description: string
+  client: string
+  location: string
+}
+
 export type JobRequest = {
   title: string
   tagline: string


### PR DESCRIPTION
- Forms for some PATCH requests are now reset when the modal is closed (applies to BusinessInfoUpdater, ServiceUpdater, and JobUpdater).
- Admins can now update the following details of any job: title, tagline, description, client, and location.